### PR TITLE
Develop

### DIFF
--- a/src/datasets/veri.py
+++ b/src/datasets/veri.py
@@ -14,7 +14,7 @@ class VeRi(BaseImageDataset):
     Liu, X., Liu, W., Ma, H., Fu, H.: Large-scale vehicle re-identification in urban surveillance videos. In: IEEE   %
     International Conference on Multimedia and Expo. (2016) accepted.
 
-    Dataset statistics:
+    Dataset statistics: Total images
     # identities: 776 vehicles(576 for training and 200 for testing)
     # images: 37778 (train) + 11579 (query)
     """
@@ -69,8 +69,16 @@ class VeRi(BaseImageDataset):
         if not osp.exists(self.gallery_dir):
             raise RuntimeError(f'"{self.gallery_dir}" is not available')
 
+    '''
+    Read images as per the file names mentioned in corresponding text files
+    name_test.txt, name_query.txt, name_test.txt
+    '''
     def process_dir(self, dir_path, relabel=False):
-        img_paths = glob.glob(osp.join(dir_path, "*.jpg"))
+        img_paths = []
+        with open(osp.join(self.dataset_dir, "name_" + dir_path.split("_")[-1] + ".txt"), "r") as file:
+            for image_name in file:
+                image_name = image_name.rstrip("\n")
+                img_paths.append(osp.join(dir_path, image_name))
         pattern = re.compile(r"([-\d]+)_c([-\d]+)")
 
         pid_container = set()

--- a/src/datasets/veri.py
+++ b/src/datasets/veri.py
@@ -71,13 +71,13 @@ class VeRi(BaseImageDataset):
 
     '''
     Read images as per the file names mentioned in corresponding text files
-    name_test.txt, name_query.txt, name_test.txt
+    name_train.txt, name_query.txt, name_test.txt
     '''
     def process_dir(self, dir_path, relabel=False):
         img_paths = []
         with open(osp.join(self.dataset_dir, "name_" + dir_path.split("_")[-1] + ".txt"), "r") as file:
             for image_name in file:
-                image_name = image_name.rstrip("\n")
+                image_name = image_name.rstrip()
                 img_paths.append(osp.join(dir_path, image_name))
         pattern = re.compile(r"([-\d]+)_c([-\d]+)")
 


### PR DESCRIPTION
Added the logic to load only the images mentioned in the respective text files (name_train.txt, name_query.txt, name_test.txt).

Attached files
1. log_train_full_dataset.txt - Sample run with current code base. Loading all images for training, testing etc

Image Dataset statistics:
  ----------------------------------------
  subset   | # ids | # images | # cameras
  ----------------------------------------
  train    |   576 |    37778 |        20
  query    |   200 |     1678 |        19
  gallery  |   200 |    11579 |        19

3. log_train_small_dataset.txt - Sample run with small dataset. Loading images mentioned in the text files

Image Dataset statistics:
  ----------------------------------------
  subset   | # ids | # images | # cameras
  ----------------------------------------
  train    |   575 |     8595 |        20
  query    |   200 |      596 |        19
  gallery  |   200 |     2000 |        19
[log_train_full_dataset.txt](https://github.com/Surrey-EEEM071-CVDL/2024CourseWork/files/15048684/log_train_full_dataset.txt)
[log_train_small_dataset.txt](https://github.com/Surrey-EEEM071-CVDL/2024CourseWork/files/15048685/log_train_small_dataset.txt)
